### PR TITLE
Fix NiceGUI paragraph spelling

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -159,7 +159,7 @@ export default function Home() {
                     <h3 className="text-lg font-bold">NiceGUI</h3>
                     <p>
                       A new Python GUI framework wrapping VueJS allowing Python
-                      devlopers build web app front ends in Python, inject
+                      developers build web app front ends in Python, inject
                       custom JS, use Quasar styled components, and TailwindCSS.
                       It&apos;s a lot of fun! You can spin up simple web apps in
                       minutes, and it&apos;s a really interesting way to build


### PR DESCRIPTION
## Summary
- fix a typo in the NiceGUI paragraph of index page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684261fd31d48324bd85a8550c7a5d53